### PR TITLE
feat: adding asset id to deployment

### DIFF
--- a/packages/go/model/model.go
+++ b/packages/go/model/model.go
@@ -236,9 +236,17 @@ type RemoteService struct {
 }
 
 type Deployment struct {
-	Kind     string         `json:"kind"`    
-	Metadata Metadata       `json:"metadata"`
-	Spec     DeploymentSpec `json:"spec"`    
+	Kind     string             `json:"kind"`    
+	Metadata DeploymentMetadata `json:"metadata"`
+	Spec     DeploymentSpec     `json:"spec"`    
+}
+
+type DeploymentMetadata struct {
+	AssetId     *string `json:"assetId,omitempty"`    
+	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name"`                 
+	Title       *string `json:"title,omitempty"`      
+	Visibility  *string `json:"visibility,omitempty"` 
 }
 
 type DeploymentSpec struct {

--- a/packages/go/schemas/concepts/core/deployment.json
+++ b/packages/go/schemas/concepts/core/deployment.json
@@ -131,7 +131,12 @@
           "const": "core/deployment"
         },
         "metadata": {
-          "$ref": "/core/metadata"
+          "$ref": "/core/metadata",
+          "properties": {
+            "assetId": {
+              "type": "string"
+            }
+          }
         },
         "spec": {
           "type": "object",

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kapeta</groupId>
     <artifactId>schemas</artifactId>
-    <version>0.0.58</version>
+    <version>0.0.59</version>
 
     <licenses>
         <license>

--- a/packages/maven/src/main/java/com/kapeta/schemas/entity/Deployment.java
+++ b/packages/maven/src/main/java/com/kapeta/schemas/entity/Deployment.java
@@ -3,6 +3,6 @@ package com.kapeta.schemas.entity;
 @lombok.Data
 public class Deployment {
     private String kind;
-    private Metadata metadata;
+    private DeploymentMetadata metadata;
     private DeploymentSpec spec;
 }

--- a/packages/maven/src/main/java/com/kapeta/schemas/entity/DeploymentMetadata.java
+++ b/packages/maven/src/main/java/com/kapeta/schemas/entity/DeploymentMetadata.java
@@ -1,0 +1,10 @@
+package com.kapeta.schemas.entity;
+
+@lombok.Data
+public class DeploymentMetadata {
+    private String assetId;
+    private String description;
+    private String name;
+    private String title;
+    private String visibility;
+}

--- a/packages/maven/src/main/resources/schemas/concepts/core/deployment.json
+++ b/packages/maven/src/main/resources/schemas/concepts/core/deployment.json
@@ -131,7 +131,12 @@
           "const": "core/deployment"
         },
         "metadata": {
-          "$ref": "/core/metadata"
+          "$ref": "/core/metadata",
+          "properties": {
+            "assetId": {
+              "type": "string"
+            }
+          }
         },
         "spec": {
           "type": "object",

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kapeta/schemas",
-    "version": "0.0.58",
+    "version": "0.0.59",
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",

--- a/packages/npm/schemas/concepts/core/deployment.json
+++ b/packages/npm/schemas/concepts/core/deployment.json
@@ -131,7 +131,12 @@
           "const": "core/deployment"
         },
         "metadata": {
-          "$ref": "/core/metadata"
+          "$ref": "/core/metadata",
+          "properties": {
+            "assetId": {
+              "type": "string"
+            }
+          }
         },
         "spec": {
           "type": "object",

--- a/packages/npm/src/types/index.ts
+++ b/packages/npm/src/types/index.ts
@@ -301,8 +301,17 @@ export interface RemoteService {
 
 export interface Deployment {
     kind:     string;
-    metadata: Metadata;
+    metadata: DeploymentMetadata;
     spec:     DeploymentSpec;
+    [property: string]: any;
+}
+
+export interface DeploymentMetadata {
+    assetId?:     string;
+    description?: string;
+    name:         string;
+    title?:       string;
+    visibility?:  string;
     [property: string]: any;
 }
 

--- a/schemas/concepts/deployment.yml
+++ b/schemas/concepts/deployment.yml
@@ -89,6 +89,9 @@ spec:
         const: core/deployment
       metadata:
         $ref: /core/metadata
+        properties:
+          assetId:
+            type: string
       spec:
         type: object
         required:


### PR DESCRIPTION
This is need for the deployments to have a stable id, that can survive renames etc.