### PR TITLE
feat: Add type to deployment instances

### DIFF
--- a/packages/go/model/model.go
+++ b/packages/go/model/model.go
@@ -254,14 +254,15 @@ type DeploymentNetworkEndpoint struct {
 }
 
 type DeploymentServiceInstance struct {
-	BlockDefinition *BlockDefinition       `json:"blockDefinition,omitempty"`
-	Configuration   map[string]interface{} `json:"configuration,omitempty"`  
-	FallbackDNS     string                 `json:"fallbackDNS"`              
-	Id              string                 `json:"id"`                       
-	Image           *string                `json:"image,omitempty"`          
-	Kind            string                 `json:"kind"`                     
-	Ref             string                 `json:"ref"`                      
-	Title           *string                `json:"title,omitempty"`          
+	BlockDefinition *BlockDefinition              `json:"blockDefinition,omitempty"`
+	Configuration   map[string]interface{}        `json:"configuration,omitempty"`  
+	FallbackDNS     string                        `json:"fallbackDNS"`              
+	Id              string                        `json:"id"`                       
+	Image           *string                       `json:"image,omitempty"`          
+	Kind            string                        `json:"kind"`                     
+	Ref             string                        `json:"ref"`                      
+	Title           *string                       `json:"title,omitempty"`          
+	Type            DeploymentServiceInstanceType `json:"type"`                     
 }
 
 type BlockDefinition struct {
@@ -473,6 +474,12 @@ const (
 
 type DeploymentNetworkConnectionType string
 const (
+	DeploymentNetworkConnectionTypeService DeploymentNetworkConnectionType = "service"
 	Resource DeploymentNetworkConnectionType = "resource"
-	Service DeploymentNetworkConnectionType = "service"
+)
+
+type DeploymentServiceInstanceType string
+const (
+	DeploymentServiceInstanceTypeService DeploymentServiceInstanceType = "service"
+	Operator DeploymentServiceInstanceType = "operator"
 )

--- a/packages/go/schemas/concepts/core/deployment.json
+++ b/packages/go/schemas/concepts/core/deployment.json
@@ -75,13 +75,22 @@
             },
             "blockDefinition": {
               "$ref": "/core/block-definition"
+            },
+            "type": {
+              "title": "DeploymentServiceInstanceType",
+              "type": "string",
+              "enum": [
+                "operator",
+                "service"
+              ]
             }
           },
           "required": [
             "id",
             "fallbackDNS",
             "kind",
-            "ref"
+            "ref",
+            "type"
           ]
         },
         "DeploymentNetworkEndpoint": {

--- a/packages/maven/src/main/java/com/kapeta/schemas/entity/DeploymentServiceInstance.java
+++ b/packages/maven/src/main/java/com/kapeta/schemas/entity/DeploymentServiceInstance.java
@@ -12,4 +12,5 @@ public class DeploymentServiceInstance {
     private String kind;
     private String ref;
     private String title;
+    private DeploymentServiceInstanceType type;
 }

--- a/packages/maven/src/main/java/com/kapeta/schemas/entity/DeploymentServiceInstanceType.java
+++ b/packages/maven/src/main/java/com/kapeta/schemas/entity/DeploymentServiceInstanceType.java
@@ -1,0 +1,21 @@
+package com.kapeta.schemas.entity;
+
+import java.io.IOException;
+
+public enum DeploymentServiceInstanceType {
+    OPERATOR, SERVICE;
+
+    public String toValue() {
+        switch (this) {
+            case OPERATOR: return "operator";
+            case SERVICE: return "service";
+        }
+        return null;
+    }
+
+    public static DeploymentServiceInstanceType forValue(String value) throws IOException {
+        if (value.equals("operator")) return OPERATOR;
+        if (value.equals("service")) return SERVICE;
+        throw new IOException("Cannot deserialize DeploymentServiceInstanceType");
+    }
+}

--- a/packages/maven/src/main/resources/schemas/concepts/core/deployment.json
+++ b/packages/maven/src/main/resources/schemas/concepts/core/deployment.json
@@ -75,13 +75,22 @@
             },
             "blockDefinition": {
               "$ref": "/core/block-definition"
+            },
+            "type": {
+              "title": "DeploymentServiceInstanceType",
+              "type": "string",
+              "enum": [
+                "operator",
+                "service"
+              ]
             }
           },
           "required": [
             "id",
             "fallbackDNS",
             "kind",
-            "ref"
+            "ref",
+            "type"
           ]
         },
         "DeploymentNetworkEndpoint": {

--- a/packages/npm/schemas/concepts/core/deployment.json
+++ b/packages/npm/schemas/concepts/core/deployment.json
@@ -75,13 +75,22 @@
             },
             "blockDefinition": {
               "$ref": "/core/block-definition"
+            },
+            "type": {
+              "title": "DeploymentServiceInstanceType",
+              "type": "string",
+              "enum": [
+                "operator",
+                "service"
+              ]
             }
           },
           "required": [
             "id",
             "fallbackDNS",
             "kind",
-            "ref"
+            "ref",
+            "type"
           ]
         },
         "DeploymentNetworkEndpoint": {

--- a/packages/npm/src/types/index.ts
+++ b/packages/npm/src/types/index.ts
@@ -339,6 +339,7 @@ export interface DeploymentServiceInstance {
     kind:             string;
     ref:              string;
     title?:           string;
+    type:             DeploymentServiceInstanceType;
     [property: string]: any;
 }
 
@@ -373,6 +374,11 @@ export interface LanguageTargetReference {
     kind:     string;
     options?: { [key: string]: any };
     [property: string]: any;
+}
+
+export enum DeploymentServiceInstanceType {
+    Operator = "operator",
+    Service = "service",
 }
 
 export interface DeploymentTargetReference {

--- a/schemas/concepts/deployment.example.yml
+++ b/schemas/concepts/deployment.example.yml
@@ -30,6 +30,7 @@ spec:
       image: docker.kapeta.com/kapeta/nodejs-sample-todo-ui:0.0.9
       configuration:
         block-specific-config: true
+      type: service
 
     - id: todo-api
       kind: kapeta/block-type-service
@@ -39,6 +40,7 @@ spec:
       image: docker.kapeta.com/kapeta/nodejs-sample-todo-service:0.0.5
       configuration:
         block-specific-config: true
+      type: service
 
     - id: users-api
       title: Users API
@@ -48,6 +50,7 @@ spec:
       image: docker.kapeta.com/kapeta/nodejs-sample-users-service:0.0.4
       configuration:
         block-specific-config: true
+      type: service
 
     - id: postgres
       title: Main postgres
@@ -59,6 +62,7 @@ spec:
         tier: db-custom-1-3840
         availabilityType: ZONAL
         storage: 10Gi
+      type: operator
 
     - id: mongodb4
       title: Main Mongo
@@ -69,6 +73,7 @@ spec:
         version: "4.4.17"
         storage: 10Gi
         diskType: premium-rwo
+      type: operator
 
     - id: mongodb6
       title: Smaller Mongo
@@ -79,6 +84,7 @@ spec:
         version: "6.0.2"
         storage: 10Gi
         diskType: standard
+      type: operator
 
   network:
     - type: resource

--- a/schemas/concepts/deployment.yml
+++ b/schemas/concepts/deployment.yml
@@ -53,11 +53,18 @@ spec:
             additionalProperties: true
           blockDefinition:
             $ref: /core/block-definition
+          type:
+            title: DeploymentServiceInstanceType
+            type: string
+            enum:
+              - operator
+              - service
         required:
           - id
           - fallbackDNS
           - kind
           - ref
+          - type
       DeploymentNetworkEndpoint:
         type: object
         properties:


### PR DESCRIPTION
Needed to communicate intent for block operators that both act as instances themselves and require operator definitions